### PR TITLE
Add a constructor for alternative initialization

### DIFF
--- a/src/main/kotlin/co/zsmb/verbalexpressions/VerEx.kt
+++ b/src/main/kotlin/co/zsmb/verbalexpressions/VerEx.kt
@@ -2,7 +2,7 @@ package co.zsmb.verbalexpressions
 
 import java.util.regex.Pattern
 
-class VerEx {
+class VerEx(construct: VerEx.() -> Unit = {}) {
 
     companion object {
         private val symbols = mapOf(
@@ -20,6 +20,10 @@ class VerEx {
     private var source = StringBuilder()
     private var suffixes = StringBuilder()
     private var modifiers = Pattern.MULTILINE
+    
+    init {
+        construct()
+    }
 
     //// COMPUTED PROPERTIES ////
 

--- a/src/test/kotlin/co/zsmb/verbalexpressions/ConstructorTest.kt
+++ b/src/test/kotlin/co/zsmb/verbalexpressions/ConstructorTest.kt
@@ -1,0 +1,23 @@
+package co.zsmb.verbalexpressions
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConstructorTest {
+    
+    @Test
+    fun useConstructor() {
+        
+        val verex = VerEx {
+            startOfLine()
+            then("http")
+            maybe("s")
+            then("://")
+            maybe("www")
+            anythingBut(" ")
+            endOfLine()
+        }
+        
+        assertTrue("https://www.google.com" matches verex)
+    }
+}


### PR DESCRIPTION
Added a constructor that executes a lambda member function, to enable composition with a block instead of periods:
```kotlin
val verex = VerEx {
    startOfLine()
    then("http")
    maybe("s")
    then("://")
    maybe("www")
    anythingBut(" ")
    endOfLine()
}
```
The empty constructor is still available, but you have to admit - this looks much cooler.